### PR TITLE
[ISSUE] Google isn't default search engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Microsoft Edge and Chromium Open Source: Our Intent
-Authors: Microsoft Edge Team  
+Authors: Microsoft Edge Team   
 Last Updated: 2018-12-06
 
 ## Why this document 


### PR DESCRIPTION
Hi. Very inconvenient after each installation search for option to change search engine from Bing to Google. Please make Google default